### PR TITLE
Pull out resolve and schema tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,14 @@
 STYLESDIR = ../asciidoctor-stylesheet-factory/stylesheets
 STYLESHEET = juxt.css
 
-.PHONY:	watch default deploy test 
+.PHONY:	watch default deploy test
 
 official-test:
 	clj -Atest -i :official
 
 test-clj:
 	clojure -Atest -e deprecated
+
 test-cljs:
 	rm -rf cljs-test-runner-out && mkdir -p cljs-test-runner-out/gen && clojure -Sverbose -Atest-cljs
 
@@ -25,7 +26,7 @@ pom:
 dev-pom:
 	rm pom.xml && clojure -R:dev:dev-rebel:dev-nrepl:test-cljs -C:dev:dev-rebel:dev-nrepl:test-cljs -Spom
 
-deploy:			
+deploy:
 	pom
 	mvn deploy
 

--- a/jsonschema.cljs.edn
+++ b/jsonschema.cljs.edn
@@ -1,0 +1,4 @@
+^{:auto-testing true
+  :open-url false
+  :watch-dirs ["src" "test"]}
+{:main juxt.jsonschema.validate}

--- a/src/juxt/jsonschema/core.cljc
+++ b/src/juxt/jsonschema/core.cljc
@@ -1,6 +1,5 @@
 (ns juxt.jsonschema.core
-  (:refer-clojure :exclude [number? integer?])
-  (:require [juxt.jsonschema.regex :as regex]))
+  (:refer-clojure :exclude [number? integer? array? object?]))
 
 (defn number? [x]
   (clojure.core/number? x))

--- a/test/cljs-test-opts.edn
+++ b/test/cljs-test-opts.edn
@@ -1,4 +1,4 @@
-{:optimizations :advanced
+{:optimizations :none
  :cache-analysis true
  :pseudo-names true
  :infer-externs false

--- a/test/juxt/jsonschema/resolve_test.cljc
+++ b/test/juxt/jsonschema/resolve_test.cljc
@@ -1,11 +1,20 @@
 ;; Copyright © 2019, JUXT LTD.
 
 (ns juxt.jsonschema.resolve-test
-  (:require
-   [cheshire.core :as cheshire]
-   [clojure.java.io :as io]
-   [juxt.jsonschema.resolve :refer [resolve-uri]]
-   [clojure.test :refer [deftest is are testing]]))
+  #?@(:clj [(:require
+             [juxt.jsonschema.resolve :refer [resolve-uri]]
+             [clojure.string :as str]
+             [cheshire.core :as cheshire]
+             [clojure.java.io :as io]
+             [lambdaisland.uri :as uri]
+             [clojure.test :refer [deftest is are testing]])]
+      :cljs [(:require
+              [juxt.jsonschema.resolve :refer [resolve-uri]]
+              [clojure.string :as str]
+              [cljs-node-io.file :refer [File]]
+              [lambdaisland.uri :as uri]
+              [cljs.test :refer-macros [deftest is are testing run-tests]])
+             (:import goog.Uri)]))
 
 (comment
   :resolvers [[:juxt.jsonschema.resolve/default-resolver {"http://example.com/foo" (io/resource "schemas/json-schema.org/draft-07/schema")}]
@@ -15,16 +24,29 @@
   (is
    (resolve-uri :juxt.jsonschema.resolve/built-in "http://json-schema.org/draft-07/schema")))
 
+
 (def example-map
-  {"http://example.com/test" (io/resource "juxt/jsonschema/test.json")
-   "http://example.com/literal-boolean-schema" false
-   "http://example.com/literal-object-schema" {:type "string"}
-   "http://example.com/literal-function-schema"
-   (fn [_] {:type "string"
-            :uri "http://example.com/literal-function-schema"})
-   #"http://example.com/static/(.*)" {:type "object"}
-   #"http://example.com/schemas/(.*)" (fn [match] {:type "object"
-                                                   :path (second match)})})
+  #?(:clj
+     {"http://example.com/test" (io/resource "juxt/jsonschema/test.json")
+      "http://example.com/literal-boolean-schema" false
+      "http://example.com/literal-object-schema" {:type "string"}
+      "http://example.com/literal-function-schema"
+      (fn [_] {:type "string"
+               :uri "http://example.com/literal-function-schema"})
+      #"http://example.com/static/(.*)" {:type "object"}
+      #"http://example.com/schemas/(.*)" (fn [match] {:type "object"
+                                                      :path (second match)})}
+     :cljs
+     {"http://example.com/test" (File. "test/juxt/jsonschema/test.json")
+      "http://example.com/literal-boolean-schema" false
+      "http://example.com/literal-object-schema" {:type "string"}
+      "http://example.com/literal-function-schema"
+      (fn [_] {:type "string"
+               :uri "http://example.com/literal-function-schema"})
+      #"http://example.com/static/(.*)" {:type "object"}
+      #"http://example.com/schemas/(.*)" (fn [match] {:type "object"
+                                                      :path (second match)})}))
+
 
 (deftest default-resolver-test
   (let [m example-map]

--- a/test/juxt/jsonschema/schema_test.cljc
+++ b/test/juxt/jsonschema/schema_test.cljc
@@ -1,10 +1,14 @@
 (ns juxt.jsonschema.schema-test
   (:require
-   [clojure.test :refer [deftest is are testing]]
-   [juxt.jsonschema.schema :as schema])
-  (:import
-   (clojure.lang ExceptionInfo)))
-
+   [juxt.jsonschema.schema :as schema]
+   #?(:clj
+      [clojure.test :refer [deftest is are testing]]
+      :cljs
+      [cljs.test :refer-macros [deftest is testing run-tests]]
+      [cljs.core :refer [ExceptionInfo]]))
+  #?(:clj
+     (:import
+      (clojure.lang ExceptionInfo))))
 
 (deftest type-test
   (testing "bad type"


### PR DESCRIPTION
Usage: `make test`


```
# shivekkhurana @ wavewalker in ~/WIP/Juxt/json-schema on git:shivekkhurana/add-tests o [13:36:05]
$ make test
make test-clj && make test-cljs
clojure -Atest -e deprecated

Running tests in #{"test"}

Testing juxt.jsonschema.annotation-test

Testing juxt.jsonschema.official-test

Testing juxt.jsonschema.regex-test

Testing juxt.jsonschema.resolve-test

Testing juxt.jsonschema.schema-test

Testing juxt.jsonschema.validate-test

Ran 50 tests containing 175 assertions.
0 failures, 0 errors.
rm -rf cljs-test-runner-out && mkdir -p cljs-test-runner-out/gen && clojure -Sverbose -Atest-cljs
version      = 1.9.0.358
install_dir  = /usr/local/Cellar/clojure/1.9.0.358
config_dir   = /Users/shivekkhurana/.clojure
config_paths = /usr/local/Cellar/clojure/1.9.0.358/deps.edn /Users/shivekkhurana/.clojure/deps.edn deps.edn
cache_dir    = .cpcache
cp_file      = .cpcache/1483057621.cp


Testing juxt.jsonschema.resolve-test

Testing juxt.jsonschema.schema-test

Ran 35 tests containing 119 assertions.
0 failures, 0 errors.

```