### PR TITLE
Allow nested objects to be passed through transformations

### DIFF
--- a/src/juxt/jinx/alpha/validate.cljc
+++ b/src/juxt/jinx/alpha/validate.cljc
@@ -651,7 +651,7 @@
             res (validate* new-schema instance new-ctx)
             causes (::jinx/errors res)]
         (cond-> res
-          causes
+          (seq causes)
           (-> (assoc ::jinx/errors [{:message "Schema failed following ref" :causes causes}]))))
 
       ;; Start with an ordered list of known of validation keywords,

--- a/src/juxt/jinx/alpha/vocabularies/transformation.cljc
+++ b/src/juxt/jinx/alpha/vocabularies/transformation.cljc
@@ -84,6 +84,15 @@
 
                (cond-> acc
 
+                 :always
+                 (merge acc
+                        (cond
+                          (::jinx/property subschema)
+                          {(::jinx/property subschema) (::jinx/instance subschema)}
+
+                          :else
+                          (::jinx/instance subschema)))
+
                  (::transformed-value subschema)
                  (assoc (::jinx/property subschema)
                         (::transformed-value subschema))

--- a/test/juxt/jinx/validate_test.cljc
+++ b/test/juxt/jinx/validate_test.cljc
@@ -424,3 +424,12 @@
                                     "bar" {"type" "integer"
                                            "const" 2}}}]}}}
          {"bar" 2})))))
+
+(deftest ref-test
+  (is
+   (empty?
+    (::jinx/errors
+     (validate/validate
+      {"$ref" "#/schemas/A"}
+      {"a" "b"}
+      {:base-document {"schemas" {"A" {"type" "object"}}}})))))

--- a/test/juxt/jinx/vocabularies/transformation_test.cljc
+++ b/test/juxt/jinx/vocabularies/transformation_test.cljc
@@ -1,0 +1,53 @@
+(ns juxt.jinx.vocabularies.transformation-test
+  (:require [juxt.jinx.alpha.vocabularies.transformation :as transformation]
+            [juxt.jinx.alpha.validate :as validate]
+            #?(:clj
+               [clojure.test :refer [deftest is testing]]
+               :cljs
+               [cljs.test :refer-macros [deftest is testing run-tests]])
+            [juxt.jinx.alpha :as jinx]))
+
+(alias 'jinx 'juxt.jinx.alpha)
+
+(deftest process-transformations-test
+  (testing "we preserve nested object schemas"
+    (is
+     (= {"a" "foo"
+         "b" {"c" "bar"}}
+        (::jinx/instance
+         (transformation/process-transformations
+          (validate/validate
+           {"type" "object"
+            "properties"
+            {"a" {"type" "string"}
+             "b" {"type" "object"
+                  "properties" {"c" {"type" "string"}}}}}
+           {"a" "foo"
+            "b" {"c" "bar"}}))))))
+
+  (testing "we preserve nested array schemas"
+    (is
+     (= {"a" "foo"
+         "b" ["bar"]}
+        (::jinx/instance
+         (transformation/process-transformations
+          (validate/validate
+           {"type" "object"
+            "properties"
+            {"a" {"type" "string"}
+             "b" {"type" "array"
+                  "items" {"type" "string"}}}}
+           {"a" "foo"
+            "b" ["bar"]}))))))
+
+  (testing "we preserve transformed values"
+    (is
+     (= {"a" :foo}
+        (::jinx/instance
+         (transformation/process-transformations
+          (validate/validate
+           {"type" "object"
+            "properties"
+            {"a" {"type" "string"
+                  "juxt.jinx.alpha/as" "keyword"}}}
+           {"a" "foo"})))))))


### PR DESCRIPTION
Currently process-transformations elides all nested schema.

Additionally, we fix a minor snare with error messages coming back for all $ref
schemas.